### PR TITLE
load articles via createContentLoader

### DIFF
--- a/.vitepress/theme/articles.data.ts
+++ b/.vitepress/theme/articles.data.ts
@@ -1,0 +1,27 @@
+import dayjs from "dayjs";
+import { createContentLoader } from "vitepress";
+
+interface Article {
+  url: string
+  title: string
+  date: string
+  tags: string[]
+}
+
+const data = [] as Article[];
+export { data };
+
+export default createContentLoader<Article[]>("articles/*.md", {
+  transform: (raw) => raw
+    .reduce((acc: Article[], page) => {
+      const date = dayjs(page.frontmatter.date);
+      if (date.isAfter(dayjs())) { return acc; }
+      return [...acc, {
+        url: page.url,
+        title: page.frontmatter.title,
+        date: date.format("DD.MM.YY"),
+        tags: page.frontmatter.tags
+      }];
+    }, [])
+    .sort((a, b) => dayjs(b.date).unix() - dayjs(a.date).unix())
+});

--- a/.vitepress/theme/components/article-list.vue
+++ b/.vitepress/theme/components/article-list.vue
@@ -1,42 +1,15 @@
 <template>
   <ul class="article-list">
-    <li v-for="{ url, date, title } in pages" :key="url">
+    <li v-for="{ url, date, title } in data" :key="url">
       <a :href="url">
-        <span class="date">[{{ date.format('DD.MM.YY') }}]</span>
+        <span class="date">[{{ date }}]</span>
         {{ title }}
       </a>
     </li>
   </ul>
 </template>
 <script setup lang="ts">
-import { ref } from "vue";
-import dayjs, { type Dayjs } from "dayjs";
-
-interface Article {
-  title: string
-  date: Dayjs
-  url: string
-}
-
-function getArticles() {
-  const files = import.meta.glob("/articles/*.md", { eager: true }) as Record<string, any>;
-  const articles: Article[] = [];
-  for (const [path, module] of Object.entries(files)) {
-    const frontmatter = module?.frontmatter ?? module?.__pageData?.frontmatter;
-    if (!frontmatter || dayjs(frontmatter.date).isAfter(dayjs())) continue;
-
-    const { title, date } = frontmatter;
-    articles.push({
-      title,
-      date: dayjs(date),
-      url: path.replace(".md", "")
-    });
-  }
-
-  return articles.sort((a, b) => b.date.valueOf() - a.date.valueOf());
-}
-
-const pages = ref<Article[]>(getArticles());
+import { data } from "../articles.data";
 </script>
 <style lang="scss">
 .article-list {
@@ -44,10 +17,10 @@ const pages = ref<Article[]>(getArticles());
   list-style: none;
   li {
     margin: 0.5em 0;
+    .date {
+      font-family: monospace;
+      color: #888;
+    }
   }
-}
-.date {
-  font-family: monospace;
-  color: #888;
 }
 </style>


### PR DESCRIPTION
Как-то слишком много конвертаций дат получилось. Можно попробовать уменьшить, переписав в transform всё на `.reduce`. Но даже если там обернуть дату в `dayjs`, экспортируется она все равно в string и поэтому в компоненте нужно снова оборачивать в dayjs 🤔

Еще какой-то беспорядок с файлами получается, но этот data.loader не работает из .vitepress

Референс: https://vitepress.dev/ru/guide/data-loading