### PR TITLE
localize 404 page

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -64,6 +64,12 @@ export default defineConfig({
     docFooter: { prev: false, next: false },
     footer: {
       copyright: "<a href=\"https://creativecommons.org/licenses/by-nc-sa/4.0/\" target=\"_blank\" rel=\"noopener noreferrer\" title=\"Открыть текст лицензии CC-BY-NC-SA 4.0\">CC-BY-NC-SA 4.0</a> © 2025 JS F/k Team"
+    },
+    notFound: {
+      title: "СТРАНИЦА НЕ НАЙДЕНА",
+      quote: "Возможно, вы перешли по неправильной ссылке. А может, мы опять что-то сломали ¯\\_(ツ)_/¯",
+      linkLabel: "Вернуться на главную",
+      linkText: "На главную"
     }
   }
 });


### PR DESCRIPTION
| До | После |
| --- | ------- |
|![](https://github.com/user-attachments/assets/4853474d-64b8-4ce6-b7f0-c016356d4da5)|![](https://github.com/user-attachments/assets/46e979ce-b5b6-4e59-9de0-6af3a9457ff2)|

Даже если будем ставить `https://github.com/jooy2/vitepress-i18n`, автор писал, что эта страница - out-of-scope  плагина `https://github.com/jooy2/vitepress-i18n/issues/4`

