### PR TITLE
layout: move author and date to the top

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -77,7 +77,6 @@ export default defineConfig({
     }
   },
   markdown: { theme: { light: "github-light", dark: "github-dark" } },
-  lastUpdated: true,
   themeConfig: {
     outline: false,
     aside: false,
@@ -117,13 +116,6 @@ export default defineConfig({
       { text: "Статьи по датам", link: "/articles-by-date" },
       { text: "Статьи по тегам", link: "/articles-by-tag" }
     ],
-    lastUpdated: {
-      text: "Последнее обновление",
-      formatOptions: {
-        forceLocale: true,
-        dateStyle: "long"
-      }
-    },
     langMenuLabel: "Изменить язык",
     returnToTopLabel: "Вернуться к началу",
     darkModeSwitchLabel: "Оформление",

--- a/.vitepress/helpers/data.ts
+++ b/.vitepress/helpers/data.ts
@@ -1,11 +1,11 @@
-import dayjs from "dayjs";
+import { formatDate } from "./date";
 import type { Article } from "../data/articles.data";
 
 export function formatArticleEntry(article: Article): Article {
   return {
     url: article.url,
     title: article.title,
-    date: dayjs(article.date).format("DD.MM.YYYY"),
+    date: formatDate(article.date, "DD.MM.YYYY"),
     tags: article.tags
   };
 }

--- a/.vitepress/helpers/date.ts
+++ b/.vitepress/helpers/date.ts
@@ -1,0 +1,7 @@
+import dayjs from "dayjs";
+
+import("dayjs/locale/ru");
+
+export function formatDate(payload: dayjs.ConfigType, format: string): string {
+  return dayjs(payload).locale("ru").format(format);
+}

--- a/.vitepress/theme/Layout.vue
+++ b/.vitepress/theme/Layout.vue
@@ -1,13 +1,12 @@
 <template>
   <layout>
-    <template v-if="frontmatter.hero" #doc-before>
-      <img :src="frontmatter.hero" class="hero-image">
+    <template #doc-before>
+      <article-author v-if="frontmatter.author" />
+      <article-date v-if="frontmatter.date" />
+      <img v-if="frontmatter.hero" :src="frontmatter.hero" class="layout-hero">
     </template>
-    <template #doc-footer-before>
-      <author-card />
+    <template v-if="frontmatter.tags" #doc-after>
       <article-tags />
-    </template>
-    <template #doc-after>
       <client-only>
         <related-articles />
       </client-only>
@@ -17,8 +16,9 @@
 <script setup lang="ts">
 import DefaultTheme from "vitepress/theme";
 import { useFrontmatter } from "../composables/useFrontmatter";
+import ArticleAuthor from "@components/article-author.vue";
+import ArticleDate from "@components/article-date.vue";
 import ArticleTags from "@components/article-tags.vue";
-import AuthorCard from "@components/author-card.vue";
 import RelatedArticles from "@components/related-articles.vue";
 
 const { Layout } = DefaultTheme;
@@ -26,7 +26,7 @@ const { Layout } = DefaultTheme;
 const frontmatter = useFrontmatter();
 </script>
 <style lang="scss">
-.hero-image {
+.layout-hero {
   margin-bottom: 2.5rem;
 }
 </style>

--- a/.vitepress/theme/components/article-author.vue
+++ b/.vitepress/theme/components/article-author.vue
@@ -1,23 +1,24 @@
 <template>
-  <section v-if="authors.length" class="author-card">
+  <div v-if="authors.length" class="article-author">
     <a
       v-for="{ url, avatar, name } in authors"
       :key="url"
       :href="url"
       target="_blank"
-      class="author-card__entry"
+      class="article-author__entry"
     >
-      <img :src="avatar" :alt="`Аватар ${name}`" class="author-card__entry-avatar">
+      <img :src="avatar" :alt="`Аватар ${name}`" class="article-author__entry-avatar">
       <div>{{ name }}</div>
     </a>
-  </section>
+  </div>
 </template>
 <script setup lang="ts">
+import { computed } from "vue";
 import { useFrontmatter } from "../../composables/useFrontmatter";
 import { authorsData, type AuthorData } from "../../data/authors";
 
 const frontmatter = useFrontmatter();
-function getAuthorsData(): AuthorData[] {
+const authors = computed<AuthorData[]>(() => {
   const { author } = frontmatter.value;
   if (!author) { return []; }
   const authorKeys: string[] = Array.isArray(author) ? author : [author];
@@ -25,19 +26,19 @@ function getAuthorsData(): AuthorData[] {
     const data = authorsData.get(key);
     return data ? [...acc, data] : acc;
   }, []);
-}
-const authors = getAuthorsData();
+});
 </script>
 <style lang="scss">
-.author-card {
+.article-author {
   display: inline-flex;
   flex-wrap: wrap;
   gap: 2rem;
+  margin-bottom: 1rem;
   &__entry {
     display: inline-flex;
     gap: .75rem;
     align-items: center;
-    margin-bottom: 1.5rem;
+    font-size: 0.875rem;
     font-weight: 500;
     color: var(--vp-c-brand-1);
     text-decoration: none;
@@ -46,8 +47,8 @@ const authors = getAuthorsData();
       text-decoration: underline;
     }
     &-avatar {
-      width: 2.5rem;
-      height: 2.5rem;
+      width: 2rem;
+      height: 2rem;
       object-fit: cover;
       border-radius: 50%;
     }

--- a/.vitepress/theme/components/article-date.vue
+++ b/.vitepress/theme/components/article-date.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="article-date">
+    {{ dateString }}
+  </div>
+</template>
+<script setup lang="ts">
+import { computed } from "vue";
+import { useData } from "vitepress";
+import { useFrontmatter } from "../../composables/useFrontmatter";
+import { formatDate } from "../../helpers/date";
+
+const content = useData();
+const frontmatter = useFrontmatter();
+
+const DATE_FORMAT = "DD MMMM YYYY";
+const dateString = computed<string>(() => {
+  const { date } = frontmatter.value;
+  const { lastUpdated } = content.page.value;
+  return `${formatDate(date, DATE_FORMAT)} | Обновлено ${formatDate(lastUpdated, DATE_FORMAT)}`;
+});
+</script>
+<style lang="scss">
+.article-date {
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+  color: var(--vp-c-text-2);
+}
+</style>

--- a/.vitepress/theme/components/article-tags.vue
+++ b/.vitepress/theme/components/article-tags.vue
@@ -24,6 +24,7 @@ const tags = computed(() => frontmatter.value.tags ?? []);
   display: flex;
   gap: .5rem;
   padding: 0;
+  margin-block: 1rem 0.75rem;
   list-style: none;
 }
 </style>


### PR DESCRIPTION
Перенес авторов в начало. Объединил дату публикации и дату обновления

<table>
<tr>
  <td>before
  <td>after
<tr>
  <td><img width="1148" height="2291" alt="before" src="https://github.com/user-attachments/assets/da64f819-e715-4866-9c73-0f90077ab708" />
  <td><img width="1148" height="2229" alt="after" src="https://github.com/user-attachments/assets/3c0a10e2-26f2-44d0-8993-7e666de40104" />
</table>


